### PR TITLE
Add document for Remote X requirements.

### DIFF
--- a/docs/RemoteX.txt
+++ b/docs/RemoteX.txt
@@ -1,21 +1,20 @@
-= Configuring Remote X. =
+Configuring Remote X.
+=====================
 
 Basic knowledge of Remote X with SSH is assumed.  Configuring PyQT6 to
 work with remote X may need extra packages installed.
 
 When starting vrt, if the following error is generated, then additional packages are required.
-```
-Could not load the Qt platform plugin 'xcb'
-```
+
+>Could not load the Qt platform plugin 'xcb'
 
 The reason is that PyQt needs this library to be able to interact with
 the remote X server.
 
-== Installation. ==
+Installation.
+=============
 On Ubuntu, install the following package after PyQt6 is installed.
-```
-$ sudo apt install libxcb-cursor0
-```
 
+$ sudo apt install libxcb-cursor0
 
 


### PR DESCRIPTION
With most software that is X based, launching it with the correct DISPLAY environment variables set will result in the program being launched on the display listed.

This change adds a document that explains why remote X with PyQt6 may fail and how to remedy the problem.