### PR TITLE
Convert PythonVirtualEnv Document from Markdown to Text.

### DIFF
--- a/docs/PythonVirtualEnv.txt
+++ b/docs/PythonVirtualEnv.txt
@@ -1,4 +1,5 @@
-=Installation with Virtual Env.=
+Installation with Virtual Env.
+==============================
 
 In cases where full installation of required components is not
 possible, the use of venv is necessary.  This assumes that the
@@ -6,25 +7,25 @@ repository has been cloned and the current working directory is the
 top level directory in the repository.
 
 * First setup venv.
-```
+
 $ python3 -m venv .venv
-```
+
 * Activate the environment.  Be sure to use the appropriate script.
   For bash, use .venv/bin/activate, and for C shells use
   .venv/bin/activate.csh.
-```
+
 $ source .venv/bin/activate
-```
+
 
 * Install PyQt6.
-```
+
 $ pip install PyQt6
-```
+
 
 * Now source the aliases script.
-```
+
 $ source scripts.d/aliases
-```
+
 Installation and setup is now complete.  Moving forward, the venv
 activation script and aliases scripts must be run to setup the
 environment before running.


### PR DESCRIPTION
Majority of the time, documentation is read by users and developers from the command-line either using a pager (less, more, ...) or an editor (EMACS, vi, ...).  For this reason it is better to format the documentation as plain text than to have it in markdown format. Markdown makes it difficult to read using these tools.  It also requires a tool to render it.

This change updates the PythonVirtualEnv.md document and converts it to plain text.